### PR TITLE
chore(workflow): add a workflow of github actions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,42 @@
+name: build image and push
+
+on:
+  push:
+    branches:
+      - action
+    tags:
+      - '*'
+
+env:
+  MODEL_URL: https://github.com/Zeyi-Lin/HivisionIDPhotos/releases/download/pretrained-model/hivision_modnet.onnx
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download model
+        run: wget -O hivision_modnet.onnx ${{ vars.MODEL_URL || env.MODEL_URL  }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ vars.IMAGE_NAME }}:${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}


### PR DESCRIPTION
增加 [GitHub Actions](https://docs.github.com/zh/actions) 配置用于自动打包多平台镜像并上传到 [DockerHub](https://hub.docker.com/)。

合并到 `Master` 分支和添加标签都会触发 Action 操作，推送到 `Master` 分支打包的镜像标签固定为 `latest`，如果是添加标签则会使用配置的标签作为镜像标签。

### 配置
1. 首先需要在仓库的 Settings / Environments 中添加一个环境，名称设置为 `release`
<img width="1153" alt="截屏2024-09-06 19 11 30" src="https://github.com/user-attachments/assets/e7a8f7ed-b47b-4ca6-81dc-11d8d96e4b17">

2. 然后需要添加变量和密钥，其中包括：
   
  - `DOCKERHUB_TOKEN`：dockerhub 的个人访问凭证。需要添加到 `Environment secrets` 中
   - `DOCKERHUB_USERNAME`：dockerhub 注册的用户名。添加到 `Environment variables` 中（下同）
   - `IMAGE_NAME`：为配置的镜像名称
   - `MODEL_URL`（可选）：为模型下载路径，默认为 https://github.com/Zeyi-Lin/HivisionIDPhotos/releases/download/pretrained-model/hivision_modnet.onnx
   > 如下图
  <img width="700" alt="截屏2024-09-06 19 16 08" src="https://github.com/user-attachments/assets/c6907d64-ca37-41c0-a1cd-51981af8e2b0">

### 示例
- 构建过程：https://github.com/swpfY/HivisionIDPhotos/actions/runs/10737144599
- 镜像：https://hub.docker.com/r/jideaflow/hivision_idphotos/tags

### 相关文档
- https://github.com/docker/build-push-action?tab=readme-ov-file
- https://docs.docker.com/build/building/multi-platform/