### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/universal
+{
+	"name": "Default Linux Universal",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/universal:2-linux",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"onCreateCommand": "sh .devcontainer/start.sh",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"eamodio.gitlens",
+				"mhutchie.git-graph"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/start.sh
+++ b/.devcontainer/start.sh
@@ -1,0 +1,10 @@
+sudo apt-get update && sudo apt-get install ffmpeg libsm6 libxext6 -y
+
+conda create -n HivisionIDPhotos python=3.10 -y
+conda init
+echo 'conda activate HivisionIDPhotos' >> ~/.bashrc
+
+ENV_PATH="/opt/conda/envs/HivisionIDPhotos/bin"
+$ENV_PATH/pip install -r requirements.txt -r requirements-app.txt -r requirements-dev.txt
+
+$ENV_PATH/python scripts/download_model.py --models all


### PR DESCRIPTION
Devcontainer 是微软和 Github 提供的一种特性。在项目中加入一个 .devcontainer 文件夹，写好环境配置，就可以使用 github 提供的 codespace 虚拟机来运行和编辑代码。

在网页上点这个绿色键然后创建一个 codespace 之后，就会有个网页编辑器，外加已经安装好依赖的运行环境，有点像 vscode + docker。可以直接运行 `python app.py` 。 不想用网页编辑器的话，也可以直接用 VSCode 连接这个虚拟机的。

![image](https://github.com/user-attachments/assets/ab6222dc-d7c4-4537-89ab-f542a0bbea66)

![image](https://github.com/user-attachments/assets/9757488a-5568-4517-9af8-d0778d4471e6)

这样做的主要好处在于，每个开发者的电脑环境不太一样，避免出现那种 “在你的电脑上能运行，在我的电脑上报错” 的问题。而且codespace 的网速和 CPU 相当快，用起来体验还可以

一些非常著名的项目都用到了这种特性（尤其微软系的）
https://github.com/microsoft/vscode
https://github.com/microsoft/autogen
https://github.com/python/cpython

