### PR TITLE
修复两个小问题

### DIFF
--- a/demo/processor.py
+++ b/demo/processor.py
@@ -341,7 +341,7 @@ class IDPhotoProcessor:
     ):
         """生成排版照片"""
         if idphoto_json["size_mode"] in LOCALES["size_mode"][language]["choices"][1]:
-            return gr.update(visible=False)
+            return None, gr.update(visible=False)
 
         typography_arr, typography_rotate = generate_layout_photo(
             input_height=idphoto_json["size"][0],

--- a/demo/ui.py
+++ b/demo/ui.py
@@ -88,7 +88,7 @@ def create_ui(
                     with gr.Row(visible=True) as size_list_row:
                         size_list_options = gr.Dropdown(
                             choices=LOCALES["size_list"][DEFAULT_LANG]["choices"],
-                            label="预设尺寸",
+                            label=LOCALES["size_list"][DEFAULT_LANG]["label"],
                             value=LOCALES["size_list"][DEFAULT_LANG]["choices"][0],
                             elem_id="size_list",
                         )


### PR DESCRIPTION
1、“预设尺寸”不应为固定字符，改为统一由语言包中的文本。
2、修复“只换底”时依然显示排版照区块的问题。