### PR TITLE
新增Starlette表单字段大小限制与文件上传大小限制,解决接口表单参数超过1024kb出现的HTTP400错误

### DIFF
--- a/deploy_api.py
+++ b/deploy_api.py
@@ -18,6 +18,12 @@ from hivision.utils import (
 import numpy as np
 import cv2
 from starlette.middleware.cors import CORSMiddleware
+from starlette.formparsers import MultiPartParser
+
+# 设置Starlette表单字段大小限制
+MultiPartParser.max_part_size = 10 * 1024 * 1024  # 10MB
+# 设置Starlette文件上传大小限制
+MultiPartParser.max_file_size = 20 * 1024 * 1024   # 20MB
 
 app = FastAPI()
 creator = IDCreator()


### PR DESCRIPTION
从Starlette 0.40.0开始,有一个新的属性MultiPartParser.max_part_size来解决一个安全漏洞,默认为 1024KB,设置这些参数可以在声明 fastapi 应用程序之前全局覆盖 class 值