### PR TITLE
feat: dynamic layout print

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,10 @@ docker run  -d -p 7860:7860 \
 
 - 修改`demo/assets/title.md`
 
+## 5. 如何添加/修改「打印排版」中的尺寸？
+
+- 修改`demo/locales.py`中的`print_switch`字典，添加/修改新的尺寸名称和尺寸参数
+
 <br>
 
 # 📧 联系我们

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ docker run  -d -p 7860:7860 \
 
 ## 5. 如何添加/修改「打印排版」中的尺寸？
 
-- 修改`demo/locales.py`中的`print_switch`字典，添加/修改新的尺寸名称和尺寸参数
+- 修改`demo/locales.py`中的`print_switch`字典，添加/修改新的尺寸名称和尺寸参数，然后重新运行`python app.py`
 
 <br>
 

--- a/demo/locales.py
+++ b/demo/locales.py
@@ -718,6 +718,7 @@ LOCALES = {
         },
     },
     "print_switch": {
+        "shape": [[1205, 1795], [1051, 1500], [2479, 3508], [1051, 1500], [1205, 1795]],
         "en": {
             "label": "Paper size",
             "choices": ["6 inch", "5 inch", "A4", "3R", "4R"],

--- a/demo/processor.py
+++ b/demo/processor.py
@@ -442,20 +442,13 @@ class IDPhotoProcessor:
         if idphoto_json["size_mode"] in LOCALES["size_mode"][language]["choices"][1]:
             return None, False
 
-        # 预设排版照尺寸
-        SIX_INCH = [1205, 1795]
-        FIVE_INCH = [1051, 1500]
-        A4 = [2479, 3508]
-        THREE_R = [1051, 1500]
-        FOUR_R = [1205, 1795]
-
         # 预设排版照尺寸字典
         PRESET_LAYOUT_SIZE = {
-            LOCALES["print_switch"][language]["choices"][0]: SIX_INCH,
-            LOCALES["print_switch"][language]["choices"][1]: FIVE_INCH,
-            LOCALES["print_switch"][language]["choices"][2]: A4,
-            LOCALES["print_switch"][language]["choices"][3]: THREE_R,
-            LOCALES["print_switch"][language]["choices"][4]: FOUR_R,
+            choice: shape
+            for choice, shape in zip(
+                LOCALES["print_switch"][language]["choices"],
+                LOCALES["print_switch"]["shape"]
+            )
         }
         
         choose_layout_size = PRESET_LAYOUT_SIZE[idphoto_json["print_switch"]]

--- a/demo/ui.py
+++ b/demo/ui.py
@@ -351,7 +351,6 @@ def create_ui(
                         value=LOCALES["print_switch"][DEFAULT_LANG]["choices"][0],
                         interactive=True,
                     )
-                    
                 
 
                 img_but = gr.Button(


### PR DESCRIPTION
This pull request includes changes to the `README.md`, `demo/locales.py`, `demo/processor.py`, and `demo/ui.py` files to add and modify the print layout size functionality and improve code maintainability.

### Enhancements to print layout size functionality:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R381-R384): Added instructions on how to add or modify print layout sizes by updating the `print_switch` dictionary in `demo/locales.py` and rerunning the application.
* [`demo/locales.py`](diffhunk://#diff-3681e5225e019f8717306b032e7626d6f8817561d0b00e3515252c9445bbea80R721): Added a new `shape` key to the `print_switch` dictionary, which contains the dimensions for various print sizes.

### Code maintainability improvements:

* [`demo/processor.py`](diffhunk://#diff-a2f1ada610a4588dcff02da0d17a5a879030e76660b752808b7e35493d776740L445-R451): Refactored the code to remove hardcoded print layout sizes and replaced them with a dictionary that maps choices to shapes using the `print_switch` dictionary.
* [`demo/ui.py`](diffhunk://#diff-7f5d7c4b566a7c1829bfdae97af317a75daa60da82df15e74ab079ac2fa47beeL356): Removed an unnecessary blank line to improve code readability.