### PR TITLE
fix: remove deprecated `show_api` for Gradio 6.x compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,6 +74,5 @@ if __name__ == "__main__":
         server_name=args.host,
         server_port=args.port,
         favicon_path=os.path.join(root_dir, "assets/hivision_logo.png"),
-        root_path=args.root_path,
-        show_api=False,
+        root_path=args.root_path
     )

--- a/app.py
+++ b/app.py
@@ -74,5 +74,5 @@ if __name__ == "__main__":
         server_name=args.host,
         server_port=args.port,
         favicon_path=os.path.join(root_dir, "assets/hivision_logo.png"),
-        root_path=args.root_path
+        root_path=args.root_path,
     )


### PR DESCRIPTION
## Issue
Gradio 6.x moved the show_api parameter from the launch() method. This change removes the deprecated parameter to ensure compatibility with Gradio 6.x while maintaining backward compatibility. This causes a startup error:

`TypeError Blocks.launch() got an unexpected keyword argument show_api`

## fix
Removed the deprecated `show_api=False` argument from `app.launch()` in `app.py`